### PR TITLE
fix(): add special case for Macedonia

### DIFF
--- a/namecase.js
+++ b/namecase.js
@@ -96,7 +96,8 @@
         .replace(/\bMacKey\b/,      "Mackey")
         .replace(/\bMacKley\b/,     "Mackley")
         .replace(/\bMacHell\b/,     "Machell")
-        .replace(/\bMacHon\b/,      "Machon");
+        .replace(/\bMacHon\b/,      "Machon")
+        .replace(/\bMacEdonia\b/,   "Macedonia");
     }
 
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -55,6 +55,10 @@ describe('NameCase', function () {
     assert.equal('George Washington', nc('george washington'));
     assert.equal('George Washington', nc('gEoRgE wAsHiNgToN'));
   });
+
+  it('should translate to correct address', function () {
+    assert.equal('248 Macedonia Cres', nc('248 Macedonia Cres'));
+  })
 });
 
 


### PR DESCRIPTION
Namecase function auto magically updates name to incorrect name: https://app.asana.com/0/1201773465255167/1202714135586237/f

This fix checks if one of the words is converted to `MacEdonia`, and if it is, re-converts it back to  `Macedonia` which is the proper spelling.